### PR TITLE
Update eslint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Flet/semistandard/issues"
   },
   "dependencies": {
-    "eslint": "~5.4.0",
+    "eslint": "~5.16.0",
     "eslint-config-semistandard": "13.0.0",
     "eslint-config-standard": "12.0.0",
     "eslint-config-standard-jsx": "6.0.2",


### PR DESCRIPTION
Create React App complains if the eslint version is below 5.16.0. All this does is update to that version (same version that [standard](https://github.com/standard/standard) is using).

Have not updated changelog or anything.